### PR TITLE
feat(mqtt): MqttEmailService con fallback a Brevo y subscriber background service

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,5 +34,6 @@
     <PackageVersion Include="Testcontainers.MsSql" Version="4.4.0" />
     <PackageVersion Include="Permit" Version="1.8.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.5.6" />
+    <PackageVersion Include="MQTTnet" Version="4.3.7.1207" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/BackgroundJobs/MqttEmailSubscriberService.cs
+++ b/src/Infrastructure/BackgroundJobs/MqttEmailSubscriberService.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using System.Text.Json;
+using MQTTnet;
+using MQTTnet.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SAPFIAI.Infrastructure.BackgroundJobs;
+
+public class MqttEmailSubscriberService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<MqttEmailSubscriberService> _logger;
+    private IMqttClient? _client;
+
+    private const string Broker = "broker.hivemq.com";
+    private const int Port = 1883;
+    private const string TopicFilter = "sapfiai/email/#";
+
+    public MqttEmailSubscriberService(IServiceScopeFactory scopeFactory, ILogger<MqttEmailSubscriberService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var factory = new MqttFactory();
+        _client = factory.CreateMqttClient();
+
+        _client.ApplicationMessageReceivedAsync += OnMessageReceived;
+
+        var options = new MqttClientOptionsBuilder()
+            .WithTcpServer(Broker, Port)
+            .WithClientId($"sapfiai-subscriber-{Guid.NewGuid():N}")
+            .WithCleanSession(false)
+            .Build();
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!_client.IsConnected)
+                {
+                    await _client.ConnectAsync(options, stoppingToken);
+                    await _client.SubscribeAsync(TopicFilter, MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce, stoppingToken);
+                    _logger.LogInformation("MQTT subscriber conectado a {Broker}", Broker);
+                }
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "MQTT subscriber desconectado, reintentando en 15s");
+                await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+            }
+        }
+    }
+
+    private async Task OnMessageReceived(MqttApplicationMessageReceivedEventArgs e)
+    {
+        var topic = e.ApplicationMessage.Topic;
+        var payload = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment);
+        var emailType = topic.Split('/').LastOrDefault();
+
+        _logger.LogInformation("MQTT mensaje recibido en {Topic}", topic);
+
+        using var scope = _scopeFactory.CreateScope();
+        var brevo = scope.ServiceProvider.GetRequiredService<SAPFIAI.Infrastructure.Services.BrevoEmailService>();
+
+        try
+        {
+            var doc = JsonDocument.Parse(payload).RootElement;
+            var result = emailType switch
+            {
+                "2fa" => await brevo.SendTwoFactorCodeAsync(
+                    doc.GetProperty("email").GetString()!,
+                    doc.GetProperty("code").GetString()!,
+                    doc.GetProperty("userName").GetString()!),
+                "login" => await brevo.SendLoginConfirmationAsync(
+                    doc.GetProperty("email").GetString()!,
+                    doc.GetProperty("userName").GetString()!,
+                    doc.GetProperty("ipAddress").GetString()!,
+                    doc.GetProperty("loginDate").GetDateTime()),
+                "security" => await brevo.SendSecurityAlertAsync(
+                    doc.GetProperty("email").GetString()!,
+                    doc.GetProperty("userName").GetString()!,
+                    doc.GetProperty("action").GetString()!,
+                    doc.GetProperty("ipAddress").GetString()!),
+                "registration" => await brevo.SendRegistrationConfirmationAsync(
+                    doc.GetProperty("email").GetString()!,
+                    doc.GetProperty("userName").GetString()!),
+                "password-reset" => await brevo.SendPasswordResetAsync(
+                    doc.GetProperty("email").GetString()!,
+                    doc.GetProperty("userName").GetString()!,
+                    doc.GetProperty("resetToken").GetString()!),
+                _ => false
+            };
+
+            if (!result)
+                _logger.LogError("Fallo al procesar email MQTT tipo {Type}", emailType);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error procesando mensaje MQTT tipo {Type}", emailType);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_client?.IsConnected == true)
+            await _client.DisconnectAsync();
+        await base.StopAsync(cancellationToken);
+    }
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -67,7 +67,9 @@ public static class DependencyInjection
         services.AddTransient<IIdentityService, IdentityService>();
         services.AddMemoryCache();
 
-        services.AddHttpClient<IEmailService, BrevoEmailService>();
+        services.AddHttpClient<BrevoEmailService>();
+        services.AddScoped<IEmailService, MqttEmailService>();
+        services.AddHostedService<SAPFIAI.Infrastructure.BackgroundJobs.MqttEmailSubscriberService>();
         services.AddScoped<ITwoFactorService, TwoFactorService>();
         services.AddScoped<IAuditLogService, AuditLogService>();
         services.AddScoped<IAuthenticationOperations, AuthenticationOperations>();

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" />
     <PackageReference Include="Permit" />
+    <PackageReference Include="MQTTnet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Services/MqttEmailService.cs
+++ b/src/Infrastructure/Services/MqttEmailService.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using System.Text.Json;
+using MQTTnet;
+using MQTTnet.Client;
+using SAPFIAI.Application.Common.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace SAPFIAI.Infrastructure.Services;
+
+public class MqttEmailService : IEmailService
+{
+    private readonly BrevoEmailService _brevo;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<MqttEmailService> _logger;
+
+    private const string Broker = "broker.hivemq.com";
+    private const int Port = 1883;
+    private const string TopicPrefix = "sapfiai/email/";
+
+    public MqttEmailService(BrevoEmailService brevo, IConfiguration configuration, ILogger<MqttEmailService> logger)
+    {
+        _brevo = brevo;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public Task<bool> SendTwoFactorCodeAsync(string email, string code, string userName) =>
+        PublishOrFallback("2fa", new { email, code, userName },
+            () => _brevo.SendTwoFactorCodeAsync(email, code, userName));
+
+    public Task<bool> SendLoginConfirmationAsync(string email, string userName, string ipAddress, DateTime loginDate) =>
+        PublishOrFallback("login", new { email, userName, ipAddress, loginDate },
+            () => _brevo.SendLoginConfirmationAsync(email, userName, ipAddress, loginDate));
+
+    public Task<bool> SendSecurityAlertAsync(string email, string userName, string action, string ipAddress) =>
+        PublishOrFallback("security", new { email, userName, action, ipAddress },
+            () => _brevo.SendSecurityAlertAsync(email, userName, action, ipAddress));
+
+    public Task<bool> SendRegistrationConfirmationAsync(string email, string userName) =>
+        PublishOrFallback("registration", new { email, userName },
+            () => _brevo.SendRegistrationConfirmationAsync(email, userName));
+
+    public Task<bool> SendPasswordResetAsync(string email, string userName, string resetToken) =>
+        PublishOrFallback("password-reset", new { email, userName, resetToken },
+            () => _brevo.SendPasswordResetAsync(email, userName, resetToken));
+
+    private async Task<bool> PublishOrFallback(string topic, object payload, Func<Task<bool>> fallback)
+    {
+        try
+        {
+            var factory = new MqttFactory();
+            using var client = factory.CreateMqttClient();
+
+            var options = new MqttClientOptionsBuilder()
+                .WithTcpServer(Broker, Port)
+                .WithClientId($"sapfiai-{Guid.NewGuid():N}")
+                .WithCleanSession()
+                .Build();
+
+            await client.ConnectAsync(options);
+
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic($"{TopicPrefix}{topic}")
+                .WithPayload(JsonSerializer.Serialize(payload))
+                .WithQualityOfServiceLevel(MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
+                .WithRetainFlag()
+                .Build();
+
+            await client.PublishAsync(message);
+            await client.DisconnectAsync();
+
+            _logger.LogInformation("MQTT publicado en {Topic}", topic);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MQTT no disponible para {Topic}, usando fallback directo", topic);
+            return await fallback();
+        }
+    }
+}


### PR DESCRIPTION
## Descripcion\nAgrega integración MQTT usando `broker.hivemq.com` como broker gratuito para el envío resiliente de correos.\n\n## Cambios\n- `MqttEmailService` implementa `IEmailService` publicando mensajes en `sapfiai/email/#` con QoS AtLeastOnce\n- `MqttEmailSubscriberService` background service que consume los mensajes y los despacha via Brevo\n- Fallback automático a `BrevoEmailService` si el broker no está disponible\n- `MQTTnet 4.3.7.1207` agregado al Central Package Management\n\n## Flujo\n```\nIEmailService → MqttEmailService → broker.hivemq.com → MqttEmailSubscriberService → Brevo\n                      │ (falla broker)\n                      └──────────────────────────────────────────────────────────→ Brevo (fallback directo)\n```\n\n## Checklist\n- [x] Build exitoso en Release\n- [x] Sin errores de compilacion\n- [x] Sigue Clean Architecture\n- [x] Rama creada desde develop (git flow)