### PR TITLE
feat(domain): add DocumentVersion and BudgetTransfer entities

### DIFF
--- a/src/Domain/Entities/BudgetTransfer.cs
+++ b/src/Domain/Entities/BudgetTransfer.cs
@@ -14,7 +14,7 @@ public class BudgetTransfer : BaseEntity
 
     public BudgetDocument? BudgetDocument { get; private set; }
 
-    private BudgetTransfer(BudgetDocumentId budgetDocumentId, BudgetTransferType transferType, decimal previousValue, decimal newValue, string transferUser)
+    internal BudgetTransfer(BudgetDocumentId budgetDocumentId, BudgetTransferType transferType, decimal previousValue, decimal newValue, string transferUser)
     {
         BudgetDocumentId = budgetDocumentId;
         TransferType = transferType;

--- a/src/Domain/Entities/BudgetTransfer.cs
+++ b/src/Domain/Entities/BudgetTransfer.cs
@@ -1,12 +1,36 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using SAPFIAI.Domain.Enums;
+using SAPFIAI.Domain.ValueObjects;
 
-namespace SAPFIAI.Domain.Entities
+namespace SAPFIAI.Domain.Entities;
+
+public class BudgetTransfer : BaseEntity
 {
-    public class BudgetTransfer
+    public BudgetDocumentId BudgetDocumentId { get; private set; }
+    public BudgetTransferType TransferType { get; private set; }
+    public decimal PreviousValue { get; private set; }
+    public decimal NewValue { get; private set; }
+    public DateTimeOffset TransferDate { get; private set; }
+    public string TransferUser { get; private set; }
+
+    public BudgetDocument? BudgetDocument { get; private set; }
+
+    private BudgetTransfer(BudgetDocumentId budgetDocumentId, BudgetTransferType transferType, decimal previousValue, decimal newValue, string transferUser)
     {
-        
+        BudgetDocumentId = budgetDocumentId;
+        TransferType = transferType;
+        PreviousValue = previousValue;
+        NewValue = newValue;
+        TransferDate = DateTimeOffset.UtcNow;
+        TransferUser = transferUser;
     }
+
+    // Required by EF Core
+    private BudgetTransfer()
+    {
+        BudgetDocumentId = new BudgetDocumentId(Guid.Empty);
+        TransferUser = string.Empty;
+    }
+
+    public static BudgetTransfer Create(BudgetDocumentId budgetDocumentId, BudgetTransferType transferType, decimal previousValue, decimal newValue, string transferUser)
+        => new(budgetDocumentId, transferType, previousValue, newValue, transferUser);
 }

--- a/src/Domain/Entities/DocumentVersion.cs
+++ b/src/Domain/Entities/DocumentVersion.cs
@@ -17,7 +17,7 @@ public class DocumentVersion : BaseEntity
 
     public BudgetDocument? BudgetDocument { get; private set; }
 
-    private DocumentVersion(BudgetDocumentId budgetDocumentId, int versionNumber, string versionUser, decimal totalAmount, decimal executedAmount, string? remarks)
+    internal DocumentVersion(BudgetDocumentId budgetDocumentId, int versionNumber, string versionUser, decimal totalAmount, decimal executedAmount, string? remarks)
     {
         BudgetDocumentId = budgetDocumentId;
         VersionNumber = versionNumber;

--- a/src/Domain/Entities/DocumentVersion.cs
+++ b/src/Domain/Entities/DocumentVersion.cs
@@ -1,12 +1,40 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using SAPFIAI.Domain.ValueObjects;
 
-namespace SAPFIAI.Domain.Entities
+namespace SAPFIAI.Domain.Entities;
+
+public class DocumentVersion : BaseEntity
 {
-    public class DocumentVersion
+    public BudgetDocumentId BudgetDocumentId { get; private set; }
+    public int VersionNumber { get; private set; }
+    public DateTimeOffset VersionDate { get; private set; }
+    public string VersionUser { get; private set; }
+
+    // Financial snapshot
+    public decimal TotalAmount { get; private set; }
+    public decimal ExecutedAmount { get; private set; }
+    public decimal AvailableAmount => TotalAmount - ExecutedAmount;
+    public string? Remarks { get; private set; }
+
+    public BudgetDocument? BudgetDocument { get; private set; }
+
+    private DocumentVersion(BudgetDocumentId budgetDocumentId, int versionNumber, string versionUser, decimal totalAmount, decimal executedAmount, string? remarks)
     {
-        
+        BudgetDocumentId = budgetDocumentId;
+        VersionNumber = versionNumber;
+        VersionDate = DateTimeOffset.UtcNow;
+        VersionUser = versionUser;
+        TotalAmount = totalAmount;
+        ExecutedAmount = executedAmount;
+        Remarks = remarks;
     }
+
+    // Required by EF Core
+    private DocumentVersion()
+    {
+        BudgetDocumentId = new BudgetDocumentId(Guid.Empty);
+        VersionUser = string.Empty;
+    }
+
+    public static DocumentVersion Create(BudgetDocumentId budgetDocumentId, int versionNumber, string versionUser, decimal totalAmount, decimal executedAmount, string? remarks = null)
+        => new(budgetDocumentId, versionNumber, versionUser, totalAmount, executedAmount, remarks);
 }

--- a/src/Domain/Entities/budgetDocument.cs
+++ b/src/Domain/Entities/budgetDocument.cs
@@ -46,13 +46,17 @@ public class BudgetDocument
         Status = newStatus;
     }
 
-    public void AddVersion(DocumentVersion version)
+    public DocumentVersion AddVersion(int versionNumber, string versionUser, decimal totalAmount, decimal executedAmount, string? remarks = null)
     {
+        var version = new DocumentVersion(Id, versionNumber, versionUser, totalAmount, executedAmount, remarks);
         _versions.Add(version);
+        return version;
     }
 
-    public void AddTransfer(BudgetTransfer transfer)
+    public BudgetTransfer AddTransfer(BudgetTransferType transferType, decimal previousValue, decimal newValue, string transferUser)
     {
+        var transfer = new BudgetTransfer(Id, transferType, previousValue, newValue, transferUser);
         _transfers.Add(transfer);
+        return transfer;
     }
 }

--- a/src/Domain/Enums/BudgetTransferType.cs
+++ b/src/Domain/Enums/BudgetTransferType.cs
@@ -1,0 +1,10 @@
+namespace SAPFIAI.Domain.Enums;
+
+public enum BudgetTransferType
+{
+    Creation = 0,
+    Modification = 1,
+    Reduction = 2,
+    Addition = 3,
+    Cancellation = 4
+}


### PR DESCRIPTION
Implementa las entidades *DocumentVersion* y *BudgetTransfer* en la capa de dominio como parte del módulo documental presupuestal. *DocumentVersion* registra un snapshot financiero por cada versión de un documento presupuestal, y *BudgetTransfer* registra los movimientos asociados con su tipo, valores anterior y nuevo, fecha y usuario. Ambas referencian a *BudgetDocument* mediante *BudgetDocumentId* (Guid tipado). Se agrega también el enum *BudgetTransferType* con los tipos de movimiento posibles.